### PR TITLE
feat: Add CI profile for Nextest

### DIFF
--- a/rust/test/action.yaml
+++ b/rust/test/action.yaml
@@ -36,7 +36,7 @@ runs:
 
     - name: Run tests with coverage
       shell: bash
-      run: cargo llvm-cov nextest --release --lcov --output-path lcov.info
+      run: cargo llvm-cov nextest --release --profile ci --lcov --output-path lcov.info
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3


### PR DESCRIPTION
* Added `--profile ci` for nextest
* Allows us to configure how we run tests for each repo, example:
https://github.com/astraly-labs/pulse/blob/main/.config/nextest.toml